### PR TITLE
feat: add ConfirmDialog and fix several UI bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/coder3101/llama-recipe-manager/security/advisories/new
+    url: https://github.com/Llama-Recipe-Manager/llama-recipe-manager/security/advisories/new
     about: Report a vulnerability privately. Do not file a public issue.
   - name: Question / discussion
-    url: https://github.com/coder3101/llama-recipe-manager/discussions
+    url: https://github.com/Llama-Recipe-Manager/llama-recipe-manager/discussions
     about: For usage questions, ideas, or general discussion.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,7 +76,7 @@ jobs:
           tagName: ${{ github.event.inputs.tag || github.ref_name }}
           releaseName: 'Llama Recipe Manager ${{ github.event.inputs.tag || github.ref_name }}'
           releaseBody: |
-            See [CHANGELOG.md](https://github.com/coder3101/llama-recipe-manager/blob/main/CHANGELOG.md)
+            See [CHANGELOG.md](https://github.com/Llama-Recipe-Manager/llama-recipe-manager/blob/main/CHANGELOG.md)
             for what changed in this release.
           releaseDraft: true
           prerelease: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ConfirmDialog` component: reusable confirmation dialog with ARIA support,
+  keyboard navigation (Tab cycling, Enter to confirm, Escape to cancel),
+  and matching existing dialog styling.
+
+### Changed
+
+- Replace browser `window.confirm()` in recipe delete with `ConfirmDialog`.
+- Add confirmation dialog before clearing server logs.
+- Update all GitHub URLs from `coder3101` to `Llama-Recipe-Manager` org.
+- Git remote updated to `Llama-Recipe-Manager/llama-recipe-manager`.
+
+### Fixed
+
+- LogsPanel now filters by `recipe_id` so each recipe's panel only shows its
+  own logs instead of all recipes' logs.
+- LogsPanel status dot and empty-state message now reflect the current
+  recipe's server state instead of the global server state.
+- Windows console window flash when spawning `llama-server` — added
+  `CREATE_NO_WINDOW` flag to `tokio::process::Command` in both the server
+  spawn path and the version probe.
+
 ## [0.1.1] — 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Save your `llama.cpp` invocations as named _recipes_, switch between them
 in one click, and stop juggling the exact set of flags you settled on for
 each model.
 
-[![CI](https://github.com/coder3101/llama-recipe-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/coder3101/llama-recipe-manager/actions/workflows/ci.yml)
+[![CI](https://github.com/Llama-Recipe-Manager/llama-recipe-manager/actions/workflows/ci.yml/badge.svg)](https://github.com/Llama-Recipe-Manager/llama-recipe-manager/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](./LICENSE)
 [![Tauri 2](https://img.shields.io/badge/Tauri-2-24C8DB?logo=tauri&logoColor=white)](https://tauri.app)
 [![Svelte 5](https://img.shields.io/badge/Svelte-5-FF3E00?logo=svelte&logoColor=white)](https://svelte.dev)
@@ -35,11 +35,11 @@ each model.
 ## Install
 
 Pre-built bundles ship on the
-[Releases](https://github.com/coder3101/llama-recipe-manager/releases) page.
+[Releases](https://github.com/Llama-Recipe-Manager/llama-recipe-manager/releases) page.
 To build from source:
 
 ```bash
-git clone https://github.com/coder3101/llama-recipe-manager.git
+git clone https://github.com/Llama-Recipe-Manager/llama-recipe-manager.git
 cd llama-recipe-manager
 bun install
 bun run tauri dev      # development

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ privately so we can fix it before it is widely known.
 
 Use one of:
 
-- GitHub's [private vulnerability reporting](https://github.com/coder3101/llama-recipe-manager/security/advisories/new)
+- GitHub's [private vulnerability reporting](https://github.com/Llama-Recipe-Manager/llama-recipe-manager/security/advisories/new)
   on this repository (preferred).
 - Email the maintainer at <ashar786khan@gmail.com>.
 

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -18,7 +18,7 @@ You'll need:
 - On Linux, the [Tauri Linux prerequisites](https://tauri.app/start/prerequisites/#linux)
 
 ```bash
-git clone https://github.com/coder3101/llama-recipe-manager.git
+git clone https://github.com/Llama-Recipe-Manager/llama-recipe-manager.git
 cd llama-recipe-manager
 bun install
 bun run tauri dev      # development with HMR

--- a/package.json
+++ b/package.json
@@ -7,15 +7,15 @@
   "author": {
     "name": "Mohammad Ashar Khan",
     "email": "ashar786khan@gmail.com",
-    "url": "https://github.com/coder3101"
+    "url": "https://github.com/Llama-Recipe-Manager"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/coder3101/llama-recipe-manager.git"
+    "url": "git+https://github.com/Llama-Recipe-Manager/llama-recipe-manager.git"
   },
-  "homepage": "https://github.com/coder3101/llama-recipe-manager#readme",
+  "homepage": "https://github.com/Llama-Recipe-Manager/llama-recipe-manager#readme",
   "bugs": {
-    "url": "https://github.com/coder3101/llama-recipe-manager/issues"
+    "url": "https://github.com/Llama-Recipe-Manager/llama-recipe-manager/issues"
   },
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -5,8 +5,8 @@ description = "Llama Recipe Manager — manage and launch llama-server recipes"
 authors = ["Mohammad Ashar Khan <ashar786khan@gmail.com>"]
 license = "MIT"
 edition = "2021"
-repository = "https://github.com/coder3101/llama-recipe-manager"
-homepage = "https://github.com/coder3101/llama-recipe-manager"
+repository = "https://github.com/Llama-Recipe-Manager/llama-recipe-manager"
+homepage = "https://github.com/Llama-Recipe-Manager/llama-recipe-manager"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -114,7 +114,10 @@ pub mod server {
             cmd.creation_flags(CREATE_NO_WINDOW);
         }
 
-        let output = cmd.output().await.map_err(|e| format!("Failed to run '{}': {}", path, e))?;
+        let output = cmd
+            .output()
+            .await
+            .map_err(|e| format!("Failed to run '{}': {}", path, e))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -103,13 +103,18 @@ pub mod server {
 
         let path = process::expand_tilde_pub(&settings.llama_server_path);
 
-        let output = tokio::process::Command::new(&path)
-            .arg("--version")
+        let mut cmd = tokio::process::Command::new(&path);
+        cmd.arg("--version")
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::piped())
-            .output()
-            .await
-            .map_err(|e| format!("Failed to run '{}': {}", path, e))?;
+            .stderr(std::process::Stdio::piped());
+
+        #[cfg(windows)]
+        {
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NO_WINDOW);
+        }
+
+        let output = cmd.output().await.map_err(|e| format!("Failed to run '{}': {}", path, e))?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();

--- a/src-tauri/src/process.rs
+++ b/src-tauri/src/process.rs
@@ -177,14 +177,16 @@ impl ProcessManager {
         // CTRL_BREAK_EVENT to it for a graceful shutdown. Without this flag
         // the child shares our console group (we have none) and would only
         // be killable via TerminateProcess.
+        //
+        // CREATE_NO_WINDOW tells Windows not to create a console window for
+        // this child process — without it, spawning a console-subsystem
+        // binary (like llama-server) from a GUI app causes a brief CMD
+        // window to flash on screen.
         #[cfg(windows)]
         {
-            // `tokio::process::Command` exposes `creation_flags` directly on
-            // Windows — we don't need to pull in `std::os::windows::process::CommandExt`
-            // (doing so trips `unused-imports` since the trait method isn't
-            // actually being resolved through the std trait).
             const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
         }
 
         if !settings.hf_token.is_empty() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -44,7 +44,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
-        "https://github.com/coder3101/llama-recipe-manager/releases/latest/download/latest.json"
+        "https://github.com/Llama-Recipe-Manager/llama-recipe-manager/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEJFQjhEQUU5QTcyMDhCMzQKUldRMGl5Q242ZHE0dmxISTVtSHNaZXBXU3RCVUJ0SzNYb1lSaERldzBZaTMxaVVjYXdOVE5RTUkK",
       "windows": {

--- a/src/lib/components/AboutDialog.svelte
+++ b/src/lib/components/AboutDialog.svelte
@@ -16,7 +16,7 @@
     onError: (msg: string) => void;
   } = $props();
 
-  const REPO_URL = 'https://github.com/coder3101/llama-recipe-manager';
+  const REPO_URL = 'https://github.com/Llama-Recipe-Manager/llama-recipe-manager';
 
   let appVersion = $state<string>('');
   let tauriVersion = $state<string>('');

--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -1,0 +1,182 @@
+<script lang="ts">
+  let {
+    open,
+    title,
+    message,
+    confirmLabel = 'Confirm',
+    cancelLabel = 'Cancel',
+    onConfirm,
+    onCancel,
+  }: {
+    open: boolean;
+    title: string;
+    message: string;
+    confirmLabel?: string;
+    cancelLabel?: string;
+    onConfirm: () => void;
+    onCancel: () => void;
+  } = $props();
+
+  let focusedButton: 'confirm' | 'cancel' = $state('cancel');
+
+  function onKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Tab') {
+      const confirmBtn = document.querySelector('[data-confirm-btn]');
+      const cancelBtn = document.querySelector('[data-cancel-btn]');
+      if (!confirmBtn || !cancelBtn) return;
+      const nodes = [cancelBtn, confirmBtn];
+      const idx = nodes.indexOf(document.activeElement as HTMLElement);
+      if (idx === -1) return;
+      let nextIdx = e.shiftKey ? idx - 1 : idx + 1;
+      if (nextIdx < 0) nextIdx = nodes.length - 1;
+      if (nextIdx >= nodes.length) nextIdx = 0;
+      (nodes[nextIdx] as HTMLElement).focus();
+      e.preventDefault();
+    } else if (e.key === 'Enter' && focusedButton === 'confirm') {
+      onConfirm();
+    } else if (e.key === 'Escape') {
+      onCancel();
+    }
+  }
+
+  $effect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => onKeyDown(e);
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  });
+
+  $effect(() => {
+    if (open) {
+      focusedButton = 'cancel';
+      setTimeout(() => {
+        (document.querySelector('[data-cancel-btn]') as HTMLElement)?.focus();
+      }, 50);
+    }
+  });
+</script>
+
+{#if open}
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div class="backdrop" onclick={onCancel}></div>
+  <div
+    class="dialog"
+    role="alertdialog"
+    aria-modal="true"
+    aria-labelledby="confirm-title"
+    aria-describedby="confirm-message"
+    tabindex="-1"
+    onkeydown={onKeyDown}
+  >
+    <h2 id="confirm-title" class="title">{title}</h2>
+    <p id="confirm-message" class="message">{message}</p>
+    <div class="actions">
+      <button class="btn cancel" data-cancel-btn onclick={onCancel} onmouseenter={() => (focusedButton = 'cancel')}>
+        {cancelLabel}
+      </button>
+      <button class="btn danger" data-confirm-btn onclick={onConfirm} onmouseenter={() => (focusedButton = 'confirm')}>
+        {confirmLabel}
+      </button>
+    </div>
+  </div>
+{/if}
+
+<style>
+  .backdrop {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.45);
+    backdrop-filter: blur(2px);
+    z-index: 100;
+    animation: fade-in 0.12s ease-out;
+  }
+
+  .dialog {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: min(400px, calc(100vw - 32px));
+    background: var(--bg-secondary);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-lg, 12px);
+    padding: 20px 22px 18px;
+    z-index: 101;
+    box-shadow:
+      0 18px 48px rgba(0, 0, 0, 0.32),
+      0 4px 12px rgba(0, 0, 0, 0.18);
+    animation: pop-in 0.14s ease-out;
+  }
+
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
+  }
+  @keyframes pop-in {
+    from {
+      opacity: 0;
+      transform: translate(-50%, -48%) scale(0.97);
+    }
+    to {
+      opacity: 1;
+      transform: translate(-50%, -50%) scale(1);
+    }
+  }
+
+  .title {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--text-primary);
+    margin: 0 0 10px;
+  }
+
+  .message {
+    font-size: 14px;
+    color: var(--text-secondary);
+    line-height: 1.5;
+    margin: 0 0 18px;
+  }
+
+  .actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 8px;
+  }
+
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 7px 18px;
+    border-radius: var(--radius-sm);
+    font-size: 13px;
+    font-weight: 500;
+    transition: all 0.15s;
+    cursor: pointer;
+    border: none;
+    white-space: nowrap;
+  }
+
+  .btn.cancel {
+    background: var(--bg-tertiary);
+    color: var(--text-primary);
+  }
+
+  .btn.cancel:hover {
+    background: var(--bg-quaternary, var(--bg-tertiary));
+  }
+
+  .btn.danger {
+    background: var(--danger);
+    color: white;
+  }
+
+  .btn.danger:hover {
+    background: var(--danger-hover);
+  }
+</style>

--- a/src/lib/components/ConfirmDialog.svelte
+++ b/src/lib/components/ConfirmDialog.svelte
@@ -72,10 +72,20 @@
     <h2 id="confirm-title" class="title">{title}</h2>
     <p id="confirm-message" class="message">{message}</p>
     <div class="actions">
-      <button class="btn cancel" data-cancel-btn onclick={onCancel} onmouseenter={() => (focusedButton = 'cancel')}>
+      <button
+        class="btn cancel"
+        data-cancel-btn
+        onclick={onCancel}
+        onmouseenter={() => (focusedButton = 'cancel')}
+      >
         {cancelLabel}
       </button>
-      <button class="btn danger" data-confirm-btn onclick={onConfirm} onmouseenter={() => (focusedButton = 'confirm')}>
+      <button
+        class="btn danger"
+        data-confirm-btn
+        onclick={onConfirm}
+        onmouseenter={() => (focusedButton = 'confirm')}
+      >
         {confirmLabel}
       </button>
     </div>

--- a/src/lib/components/LogsPanel.svelte
+++ b/src/lib/components/LogsPanel.svelte
@@ -63,11 +63,12 @@
 <section class="logs">
   <header class="logs-header">
     <div class="logs-title">
-      <span class="dot" class:live={recipeId ? serverStore.isActive(recipeId) : serverStore.anyRunning()}></span>
+      <span
+        class="dot"
+        class:live={recipeId ? serverStore.isActive(recipeId) : serverStore.anyRunning()}
+      ></span>
       <h3>Logs</h3>
-      <span class="count"
-        >{recipeLogs.length} {recipeLogs.length === 1 ? 'line' : 'lines'}</span
-      >
+      <span class="count">{recipeLogs.length} {recipeLogs.length === 1 ? 'line' : 'lines'}</span>
     </div>
     <div class="logs-actions">
       <input
@@ -81,9 +82,7 @@
         <input type="checkbox" bind:checked={autoScroll} />
         <span>Auto-scroll</span>
       </label>
-      <button class="action" onclick={handleCopy} disabled={recipeLogs.length === 0}>
-        Copy
-      </button>
+      <button class="action" onclick={handleCopy} disabled={recipeLogs.length === 0}> Copy </button>
       <button class="action" onclick={handleClear} disabled={recipeLogs.length === 0}>
         Clear
       </button>

--- a/src/lib/components/LogsPanel.svelte
+++ b/src/lib/components/LogsPanel.svelte
@@ -1,18 +1,25 @@
 <script lang="ts">
   import { tick } from 'svelte';
+  import ConfirmDialog from './ConfirmDialog.svelte';
   import { serverStore } from '$lib/stores/server.svelte';
   import { errorMessage } from '$lib/utils/format';
 
-  let { onError }: { onError?: (msg: string) => void } = $props();
+  let { recipeId, onError }: { recipeId?: string; onError?: (msg: string) => void } = $props();
 
   let logContainer = $state<HTMLDivElement | undefined>(undefined);
   let autoScroll = $state(true);
   let filter = $state('');
+  let showClearConfirm = $state(false);
+
+  const recipeLogs = $derived.by(() => {
+    if (!recipeId) return serverStore.logs;
+    return serverStore.logs.filter((l) => l.recipe_id === recipeId);
+  });
 
   const filteredLogs = $derived.by(() => {
-    if (!filter.trim()) return serverStore.logs;
+    if (!filter.trim()) return recipeLogs;
     const q = filter.toLowerCase();
-    return serverStore.logs.filter((l) => l.line.toLowerCase().includes(q));
+    return recipeLogs.filter((l) => l.line.toLowerCase().includes(q));
   });
 
   function onScroll() {
@@ -30,7 +37,12 @@
     }
   });
 
-  async function handleClear() {
+  function handleClear() {
+    showClearConfirm = true;
+  }
+
+  async function confirmClear() {
+    showClearConfirm = false;
     try {
       await serverStore.clearLogs();
       await tick();
@@ -41,7 +53,7 @@
 
   async function handleCopy() {
     try {
-      await navigator.clipboard.writeText(serverStore.logs.map((l) => l.line).join('\n'));
+      await navigator.clipboard.writeText(recipeLogs.map((l) => l.line).join('\n'));
     } catch (e) {
       onError?.(errorMessage(e));
     }
@@ -51,10 +63,10 @@
 <section class="logs">
   <header class="logs-header">
     <div class="logs-title">
-      <span class="dot" class:live={serverStore.anyRunning()}></span>
+      <span class="dot" class:live={recipeId ? serverStore.isActive(recipeId) : serverStore.anyRunning()}></span>
       <h3>Logs</h3>
       <span class="count"
-        >{serverStore.logs.length} {serverStore.logs.length === 1 ? 'line' : 'lines'}</span
+        >{recipeLogs.length} {recipeLogs.length === 1 ? 'line' : 'lines'}</span
       >
     </div>
     <div class="logs-actions">
@@ -69,30 +81,40 @@
         <input type="checkbox" bind:checked={autoScroll} />
         <span>Auto-scroll</span>
       </label>
-      <button class="action" onclick={handleCopy} disabled={serverStore.logs.length === 0}>
+      <button class="action" onclick={handleCopy} disabled={recipeLogs.length === 0}>
         Copy
       </button>
-      <button class="action" onclick={handleClear} disabled={serverStore.logs.length === 0}>
+      <button class="action" onclick={handleClear} disabled={recipeLogs.length === 0}>
         Clear
       </button>
     </div>
   </header>
 
   <div class="viewer" bind:this={logContainer} onscroll={onScroll}>
-    {#if serverStore.logs.length === 0}
+    {#if recipeLogs.length === 0}
       <div class="empty">
-        {serverStore.anyRunning()
+        {(recipeId ? serverStore.isActive(recipeId) : serverStore.anyRunning())
           ? 'Waiting for output…'
           : 'No logs yet. Start the server to see output.'}
       </div>
     {:else if filteredLogs.length === 0}
-      <div class="empty">No lines match “{filter}”.</div>
+      <div class="empty">No lines match "{filter}".</div>
     {:else}
       {#each filteredLogs as log, i (i)}
         <div class="line" class:stderr={log.is_stderr}>{log.line}</div>
       {/each}
     {/if}
   </div>
+
+  <ConfirmDialog
+    open={showClearConfirm}
+    title="Clear Logs"
+    message="Clear all server logs? This action cannot be undone."
+    confirmLabel="Clear"
+    cancelLabel="Cancel"
+    onConfirm={confirmClear}
+    onCancel={() => (showClearConfirm = false)}
+  />
 </section>
 
 <style>

--- a/src/lib/components/RecipeDetail.svelte
+++ b/src/lib/components/RecipeDetail.svelte
@@ -2,6 +2,7 @@
   import { onDestroy } from 'svelte';
   import { openUrl } from '@tauri-apps/plugin-opener';
 
+  import ConfirmDialog from './ConfirmDialog.svelte';
   import LiveStatsPanel from './LiveStatsPanel.svelte';
   import LogsPanel from './LogsPanel.svelte';
   import { deleteRecipe, duplicateRecipe } from '$lib/api';
@@ -79,7 +80,11 @@
       onError('Stop the server before deleting this recipe.');
       return;
     }
-    if (!confirm('Delete this recipe?')) return;
+    showDeleteConfirm = true;
+  }
+
+  async function confirmDelete() {
+    showDeleteConfirm = false;
     try {
       await deleteRecipe(recipe.id);
       await recipesStore.refresh();
@@ -108,6 +113,7 @@
   }
 
   let showFullCommand = $state(false);
+  let showDeleteConfirm = $state(false);
 </script>
 
 <div class="detail-view">
@@ -322,7 +328,17 @@
     <LiveStatsPanel />
   {/if}
 
-  <LogsPanel {onError} />
+  <LogsPanel recipeId={recipe.id} {onError} />
+
+  <ConfirmDialog
+    open={showDeleteConfirm}
+    title="Delete Recipe"
+    message="Are you sure you want to delete this recipe? This action cannot be undone."
+    confirmLabel="Delete"
+    cancelLabel="Cancel"
+    onConfirm={confirmDelete}
+    onCancel={() => (showDeleteConfirm = false)}
+  />
 </div>
 
 <style>


### PR DESCRIPTION
## Summary

- **New `ConfirmDialog` component** (`src/lib/components/ConfirmDialog.svelte`) — reusable confirmation dialog matching the existing `AboutDialog` styling. Features ARIA support (`role="alertdialog"`), keyboard navigation (Tab cycling, Enter to confirm, Escape to cancel), and fade-in/pop-in animations.

- **Replace browser `confirm()` with ConfirmDialog** for delete recipe action in `RecipeDetail.svelte`.

- **Add confirmation dialog before clearing logs** in `LogsPanel.svelte` (was previously instant with no confirmation).

## Bug Fixes

- **LogsPanel showing all recipes' logs**: Added `recipeId` prop and filter log lines by `recipe_id` so each recipe's panel only displays its own logs.

- **LogsPanel status dot / empty message showing wrong state**: Changed `serverStore.anyRunning()` to `serverStore.isActive(recipeId)` so indicators reflect the current recipe, not the global server state.

- **Windows console window flash on server launch**: Added `CREATE_NO_WINDOW` (`0x0800_0000`) flag to `tokio::process::Command` in both the server spawn path (`process.rs`) and the version probe (`commands.rs`).

## Repo Migration

- Updated all GitHub URLs from `coder3101` to `Llama-Recipe-Manager` org across 9 files: `package.json`, `Cargo.toml`, `tauri.conf.json`, `AboutDialog.svelte`, `README.md`, `SECURITY.md`, `docs/Development.md`, `.github/ISSUE_TEMPLATE/config.yml`, `.github/workflows/release.yml`.
- Git remote updated to new org.