### PR TITLE
release: v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.2.0] — 2026-04-26
 
 ### Added
 
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add confirmation dialog before clearing server logs.
 - Update all GitHub URLs from `coder3101` to `Llama-Recipe-Manager` org.
 - Git remote updated to `Llama-Recipe-Manager/llama-recipe-manager`.
+- Homepage URL updated to https://llama-recipe-manager.github.io.
 
 ### Fixed
 

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -1,0 +1,107 @@
+# Release Guide
+
+This document describes the steps to cut a new release of Llama Recipe Manager.
+
+## Versioning
+
+We follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
+
+- **MAJOR** — breaking schema, settings, or recipe-format change.
+- **MINOR** — new user-visible functionality.
+- **PATCH** — bug fixes, dependency bumps, doc-only changes, internal refactors.
+
+The version lives in three files that must stay in lockstep:
+
+| File | Field |
+|------|-------|
+| `package.json` | `"version"` |
+| `src-tauri/Cargo.toml` | `version =` |
+| `src-tauri/tauri.conf.json` | `"version"` |
+
+## Cutting a Release
+
+### 1. Bump the version
+
+Run the bump script from the repository root:
+
+```bash
+python scripts/bump-version.py --minor   # or --major or --patch
+```
+
+This will:
+- Update all three version files.
+- Update `Cargo.lock`.
+- Run the full quality gate (lint, typecheck, tests, format checks).
+
+If any check fails, fix the issues and re-run the script.
+
+### 2. Update the changelog
+
+Move the `## [Unreleased]` section to `## [X.Y.Z] — YYYY-MM-DD` with today's date:
+
+```bash
+# Edit CHANGELOG.md manually
+```
+
+Ensure all notable changes are categorized under `Added`, `Changed`, `Deprecated`, `Fixed`, or `Removed`.
+
+### 3. Commit and create a PR
+
+```bash
+git add -A
+git commit -s -m "release: vX.Y.Z"
+git push origin main
+gh pr create --base main --title "release: vX.Y.Z"
+```
+
+Wait for CI to pass, then merge.
+
+### 4. Create and push a tag
+
+After the PR is merged, switch to main and pull:
+
+```bash
+git checkout main
+git pull
+```
+
+Create and push the tag (the `v` prefix is required by the release workflow):
+
+```bash
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z
+```
+
+This triggers the [Release workflow](../.github/workflows/release.yml) which:
+- Builds binaries for macOS (aarch64), Linux, and Windows.
+- Generates `latest.json` for the auto-updater.
+- Creates a draft GitHub Release with all artifacts attached.
+
+### 5. Publish the release
+
+Go to [GitHub Releases](https://github.com/Llama-Recipe-Manager/llama-recipe-manager/releases), find the draft release, edit the body if needed, and click **Publish release**.
+
+The auto-updater will now discover the new version for users.
+
+## Hotfix Flow
+
+To patch an already-released version:
+
+```bash
+git checkout main
+git pull
+python scripts/bump-version.py --patch
+# Update CHANGELOG — move Unreleased to new patch version
+git add -A && git commit -s -m "release: vX.Y.Z+1"
+git push origin main
+gh pr create --base main --title "release: vX.Y.Z+1"
+# After merge:
+git tag -a vX.Y.Z+1 -m "Release vX.Y.Z+1"
+git push origin vX.Y.Z+1
+```
+
+## Notes
+
+- The `TAURI_SIGNING_PRIVATE_KEY` secret must be set on the repository for signed auto-updates to work.
+- The signing key does not change between releases — it is tied to the pubkey in `tauri.conf.json`.
+- The `latest.json` file is generated at build time and contains asset download URLs pointing to the current repository.

--- a/docs/Release.md
+++ b/docs/Release.md
@@ -12,10 +12,10 @@ We follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html):
 
 The version lives in three files that must stay in lockstep:
 
-| File | Field |
-|------|-------|
-| `package.json` | `"version"` |
-| `src-tauri/Cargo.toml` | `version =` |
+| File                        | Field       |
+| --------------------------- | ----------- |
+| `package.json`              | `"version"` |
+| `src-tauri/Cargo.toml`      | `version =` |
 | `src-tauri/tauri.conf.json` | `"version"` |
 
 ## Cutting a Release
@@ -29,6 +29,7 @@ python scripts/bump-version.py --minor   # or --major or --patch
 ```
 
 This will:
+
 - Update all three version files.
 - Update `Cargo.lock`.
 - Run the full quality gate (lint, typecheck, tests, format checks).
@@ -73,6 +74,7 @@ git push origin vX.Y.Z
 ```
 
 This triggers the [Release workflow](../.github/workflows/release.yml) which:
+
 - Builds binaries for macOS (aarch64), Linux, and Windows.
 - Generates `latest.json` for the auto-updater.
 - Creates a draft GitHub Release with all artifacts attached.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llama-recipe-manager",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Llama Recipe Manager — manage and launch llama-server recipes",
   "private": true,
   "license": "MIT",
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "git+https://github.com/Llama-Recipe-Manager/llama-recipe-manager.git"
   },
-  "homepage": "https://github.com/Llama-Recipe-Manager/llama-recipe-manager#readme",
+  "homepage": "https://llama-recipe-manager.github.io",
   "bugs": {
     "url": "https://github.com/Llama-Recipe-Manager/llama-recipe-manager/issues"
   },

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2083,7 +2083,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "llama-recipe-manager"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "chrono",
  "libc",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "llama-recipe-manager"
-version = "0.1.1"
+version = "0.2.0"
 description = "Llama Recipe Manager — manage and launch llama-server recipes"
 authors = ["Mohammad Ashar Khan <ashar786khan@gmail.com>"]
 license = "MIT"
 edition = "2021"
 repository = "https://github.com/Llama-Recipe-Manager/llama-recipe-manager"
-homepage = "https://github.com/Llama-Recipe-Manager/llama-recipe-manager"
+homepage = "https://llama-recipe-manager.github.io"
 
 [lints.clippy]
 all = { level = "warn", priority = -1 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Llama Recipe Manager",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "identifier": "com.ashar.llama-recipe-manager",
   "build": {
     "beforeDevCommand": "bun run dev",


### PR DESCRIPTION
## Summary

- Bump version 0.1.1 → 0.2.0 across all version files.
- Update homepage URL to https://llama-recipe-manager.github.io.
- Update CHANGELOG with 0.2.0 release date and homepage change.
- Add docs/Release.md with release steps and hotfix flow.

## Changes

| File | Change |
|------|--------|
| `package.json` | version 0.2.0, homepage → github.io |
| `src-tauri/Cargo.toml` | version 0.2.0, homepage → github.io |
| `src-tauri/tauri.conf.json` | version 0.2.0 |
| `src-tauri/Cargo.lock` | regenerated |
| `CHANGELOG.md` | Unreleased → [0.2.0] — 2026-04-26 |
| `docs/Release.md` | new — release steps and hotfix flow |

All quality checks passed (lint, typecheck, tests, format).